### PR TITLE
initial design implementation draft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cli_engineer"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1.36", features = ["full"] }
+thiserror = "1.0"
+log = "0.4"
+simplelog = "0.12"
+anyhow = "1.0"
+async-trait = "0.1"
+clap = { version = "4.5", features = ["derive"] }
+reqwest = { version = "0.12", features = ["json", "tls"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # cli_engineer
-autonomous CLI coding agent
+
+A skeletal implementation of an autonomous CLI coding agent written in Rust. It demonstrates the overall architecture with pluggable LLM providers, task interpretation, planning, execution, review and an agentic loop.
+
+## Building
+
+```bash
+cargo build
+```
+
+(Requires network access on first build to download dependencies.)
+
+## Usage
+
+```bash
+cargo run -- --verbose "generate hello world"
+```
+
+Use `--headless` to disable UI output.
+
+### Environment variables
+
+Select a provider by setting `LLM_PROVIDER` to one of `openai`, `anthropic`, `openrouter`, `xai`, or `ollama`. The `LLM_MODEL` variable chooses the model name. Each provider requires an API key in the corresponding variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `XAI_API_KEY`).

--- a/src/agentic_loop.rs
+++ b/src/agentic_loop.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use log::{info, error};
+
+use crate::interpreter::{Interpreter, Task};
+use crate::planner::{Planner, Plan};
+use crate::executor::Executor;
+use crate::reviewer::Reviewer;
+use crate::llm_manager::{LLMManager, LLMProvider};
+
+/// Controls the iterative planning-action-review cycle.
+pub struct AgenticLoop<'a> {
+    interpreter: Interpreter,
+    planner: Planner,
+    executor: Executor,
+    reviewer: Reviewer,
+    llm_manager: &'a LLMManager,
+    max_iterations: usize,
+}
+
+impl<'a> AgenticLoop<'a> {
+    pub fn new(llm_manager: &'a LLMManager, max_iterations: usize) -> Self {
+        Self {
+            interpreter: Interpreter::new(),
+            planner: Planner::new(),
+            executor: Executor::new(),
+            reviewer: Reviewer::new(),
+            llm_manager,
+            max_iterations,
+        }
+    }
+
+    /// Run the agentic loop on the given input.
+    pub async fn run(&self, input: &str) -> Result<()> {
+        let task = self.interpreter.interpret(input)?;
+        info!("Interpreted task: {}", task.description);
+        let provider = self.llm_manager.provider();
+        let mut iteration = 0;
+        loop {
+            if iteration >= self.max_iterations {
+                info!("Reached max iterations");
+                break;
+            }
+            iteration += 1;
+            info!("Planning iteration {}", iteration);
+            let plan: Plan = self.planner.plan(&task, provider).await?;
+            info!("Plan: {:?}", plan.steps);
+            let outputs = self.executor.execute(&plan, provider).await?;
+            info!("Execution complete");
+            match self.reviewer.review(&outputs, provider).await {
+                Ok(()) => {
+                    info!("Review succeeded");
+                    break;
+                }
+                Err(err) => {
+                    error!("Review failed: {}", err);
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use tokio::task::JoinHandle;
+
+/// Runs tasks concurrently using tokio.
+pub async fn run_parallel<T, F>(futs: Vec<F>) -> Result<Vec<T>>
+where
+    F: std::future::Future<Output = Result<T>> + Send + 'static,
+    T: Send + 'static,
+{
+    let handles: Vec<JoinHandle<Result<T>>> = futs
+        .into_iter()
+        .map(|f| tokio::spawn(f))
+        .collect();
+
+    let mut out = Vec::new();
+    for handle in handles {
+        out.push(handle.await??);
+    }
+    Ok(out)
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+
+use crate::llm_manager::LLMProvider;
+use crate::planner::Plan;
+
+/// Executes planned steps using a coding LLM.
+pub struct Executor;
+
+impl Executor {
+    pub fn new() -> Self { Self }
+
+    /// Execute each step and collect the responses.
+    pub async fn execute(&self, plan: &Plan, llm: &dyn LLMProvider) -> Result<Vec<String>> {
+        let mut outputs = Vec::new();
+        for step in &plan.steps {
+            let prompt = format!("Execute step: {}", step);
+            let resp = llm.send_prompt(&prompt).await?;
+            outputs.push(resp);
+        }
+        Ok(outputs)
+    }
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+
+/// Represents a parsed user task.
+#[derive(Debug, Clone)]
+pub struct Task {
+    pub description: String,
+}
+
+/// Interprets raw input into a `Task`.
+pub struct Interpreter;
+
+impl Interpreter {
+    pub fn new() -> Self { Self }
+
+    /// Interpret user input into a `Task`.
+    pub fn interpret(&self, input: &str) -> Result<Task> {
+        // For now just wrap the input.
+        Ok(Task { description: input.to_string() })
+    }
+}

--- a/src/llm_manager.rs
+++ b/src/llm_manager.rs
@@ -1,0 +1,298 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::time::Duration;
+
+/// Trait representing an LLM provider.
+#[async_trait]
+pub trait LLMProvider: Send + Sync {
+    /// Name of the provider.
+    fn name(&self) -> &str;
+
+    /// Maximum context size in tokens.
+    fn context_size(&self) -> usize;
+
+    /// Send a prompt to the provider and return the response.
+    async fn send_prompt(&self, prompt: &str) -> Result<String>;
+}
+
+const MAX_RETRIES: usize = 5;
+
+async fn send_with_backoff<F, Fut>(mut f: F) -> Result<String>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<reqwest::Response>>,
+{
+    let mut delay = Duration::from_secs(1);
+    for _ in 0..MAX_RETRIES {
+        match f().await {
+            Ok(resp) => {
+                if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
+                    continue;
+                }
+                if !resp.status().is_success() {
+                    let text = resp.text().await.unwrap_or_default();
+                    return Err(anyhow!(text));
+                }
+                return Ok(resp.text().await?);
+            }
+            Err(err) => {
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+                if delay.as_secs() > 32 {
+                    return Err(err.into());
+                }
+            }
+        }
+    }
+    Err(anyhow!("exceeded retries"))
+}
+
+/// Provider using the OpenAI API.
+pub struct OpenAIProvider {
+    client: Client,
+    api_key: String,
+    model: String,
+    context: usize,
+}
+
+impl OpenAIProvider {
+    pub fn new(model: &str) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY"),
+            model: model.to_string(),
+            context: 8192,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for OpenAIProvider {
+    fn name(&self) -> &str { "openai" }
+    fn context_size(&self) -> usize { self.context }
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        let payload = json!({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.0
+        });
+        let api = "https://api.openai.com/v1/chat/completions".to_string();
+        send_with_backoff(|| async {
+            self.client.post(&api)
+                .bearer_auth(&self.api_key)
+                .json(&payload)
+                .send()
+                .await
+        }).await.and_then(|text| {
+            let v: serde_json::Value = serde_json::from_str(&text)?;
+            Ok(v["choices"][0]["message"]["content"].as_str().unwrap_or("").to_string())
+        })
+    }
+}
+
+/// Provider using Anthropic models.
+pub struct AnthropicProvider {
+    client: Client,
+    api_key: String,
+    model: String,
+    context: usize,
+}
+
+impl AnthropicProvider {
+    pub fn new(model: &str) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY"),
+            model: model.to_string(),
+            context: 200000,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for AnthropicProvider {
+    fn name(&self) -> &str { "anthropic" }
+    fn context_size(&self) -> usize { self.context }
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        let payload = json!({
+            "model": self.model,
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": prompt}]
+        });
+        let api = "https://api.anthropic.com/v1/messages".to_string();
+        send_with_backoff(|| async {
+            self.client.post(&api)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .json(&payload)
+                .send()
+                .await
+        }).await.and_then(|text| {
+            let v: serde_json::Value = serde_json::from_str(&text)?;
+            Ok(v["content"][0]["text"].as_str().unwrap_or("").to_string())
+        })
+    }
+}
+
+/// Provider using OpenRouter with an OpenAI-compatible API.
+pub struct OpenRouterProvider {
+    client: Client,
+    api_key: String,
+    model: String,
+    context: usize,
+}
+
+impl OpenRouterProvider {
+    pub fn new(model: &str) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY"),
+            model: model.to_string(),
+            context: 8192,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for OpenRouterProvider {
+    fn name(&self) -> &str { "openrouter" }
+    fn context_size(&self) -> usize { self.context }
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        let payload = json!({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.0
+        });
+        let api = "https://openrouter.ai/api/v1/chat/completions".to_string();
+        send_with_backoff(|| async {
+            self.client.post(&api)
+                .header("Authorization", format!("Bearer {}", &self.api_key))
+                .json(&payload)
+                .send()
+                .await
+        }).await.and_then(|text| {
+            let v: serde_json::Value = serde_json::from_str(&text)?;
+            Ok(v["choices"][0]["message"]["content"].as_str().unwrap_or("").to_string())
+        })
+    }
+}
+
+/// Provider using xAI's Grok model.
+pub struct XAIProvider {
+    client: Client,
+    api_key: String,
+    model: String,
+    context: usize,
+}
+
+impl XAIProvider {
+    pub fn new(model: &str) -> Self {
+        Self {
+            client: Client::new(),
+            api_key: std::env::var("XAI_API_KEY").expect("XAI_API_KEY"),
+            model: model.to_string(),
+            context: 8192,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for XAIProvider {
+    fn name(&self) -> &str { "xai" }
+    fn context_size(&self) -> usize { self.context }
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        let payload = json!({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.0
+        });
+        let api = "https://api.x.ai/v1/chat/completions".to_string();
+        send_with_backoff(|| async {
+            self.client.post(&api)
+                .header("Authorization", format!("Bearer {}", &self.api_key))
+                .json(&payload)
+                .send()
+                .await
+        }).await.and_then(|text| {
+            let v: serde_json::Value = serde_json::from_str(&text)?;
+            Ok(v["choices"][0]["message"]["content"].as_str().unwrap_or("").to_string())
+        })
+    }
+}
+
+/// Provider using a local ollama server.
+pub struct OllamaProvider {
+    client: Client,
+    model: String,
+    context: usize,
+}
+
+impl OllamaProvider {
+    pub fn new(model: &str) -> Self {
+        Self {
+            client: Client::new(),
+            model: model.to_string(),
+            context: 8192,
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for OllamaProvider {
+    fn name(&self) -> &str { "ollama" }
+    fn context_size(&self) -> usize { self.context }
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        let payload = json!({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}]
+        });
+        let api = "http://localhost:11434/api/chat".to_string();
+        send_with_backoff(|| async {
+            self.client.post(&api)
+                .json(&payload)
+                .send()
+                .await
+        }).await.and_then(|text| {
+            let v: serde_json::Value = serde_json::from_str(&text)?;
+            Ok(v["message"]["content"].as_str().unwrap_or("").to_string())
+        })
+    }
+}
+
+
+/// Manager that keeps track of multiple providers and context limits.
+pub struct LLMManager {
+    providers: Vec<Box<dyn LLMProvider>>,
+    active: usize,
+}
+
+impl LLMManager {
+    /// Create a new manager with the given providers.
+    pub fn new(providers: Vec<Box<dyn LLMProvider>>) -> Self {
+        Self { providers, active: 0 }
+    }
+
+    /// Create a manager based on environment variables.
+    pub fn from_env() -> Self {
+        let provider_name = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "openai".into());
+        let model = std::env::var("LLM_MODEL").unwrap_or_else(|_| "gpt-4-turbo".into());
+        let provider: Box<dyn LLMProvider> = match provider_name.as_str() {
+            "anthropic" => Box::new(AnthropicProvider::new(&model)),
+            "openrouter" => Box::new(OpenRouterProvider::new(&model)),
+            "xai" => Box::new(XAIProvider::new(&model)),
+            "ollama" => Box::new(OllamaProvider::new(&model)),
+            _ => Box::new(OpenAIProvider::new(&model)),
+        };
+        Self::new(vec![provider])
+    }
+
+    /// Get the active provider.
+    pub fn provider(&self) -> &dyn LLMProvider {
+        &*self.providers[self.active]
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,6 @@
+use simplelog::{Config, LevelFilter, SimpleLogger};
+
+pub fn init(verbose: bool) {
+    let level = if verbose { LevelFilter::Info } else { LevelFilter::Warn };
+    let _ = SimpleLogger::init(level, Config::default());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+
+mod llm_manager;
+mod interpreter;
+mod planner;
+mod executor;
+mod reviewer;
+mod agentic_loop;
+mod concurrency;
+mod ui;
+mod logger;
+
+use llm_manager::LLMManager;
+use agentic_loop::AgenticLoop;
+
+#[derive(Parser)]
+#[command(name = "cli_engineer")]
+struct Args {
+    /// Run without UI output
+    #[arg(short, long)]
+    headless: bool,
+    /// Verbose logging
+    #[arg(short, long)]
+    verbose: bool,
+    /// Command or natural language instruction
+    #[arg(last = true)]
+    command: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    logger::init(args.verbose);
+    let ui = ui::UIHandler::new(args.headless);
+    ui.start()?;
+    let llm_manager = LLMManager::from_env();
+    let agent = AgenticLoop::new(&llm_manager, 3);
+    let input = args.command.join(" ");
+    agent.run(&input).await?;
+    Ok(())
+}

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+
+use crate::interpreter::Task;
+use crate::llm_manager::LLMProvider;
+
+/// Represents a sequence of steps to perform.
+#[derive(Debug, Clone)]
+pub struct Plan {
+    pub steps: Vec<String>,
+}
+
+pub struct Planner;
+
+impl Planner {
+    pub fn new() -> Self { Self }
+
+    /// Create a plan for the given task using the provided LLM.
+    pub async fn plan(&self, task: &Task, llm: &dyn LLMProvider) -> Result<Plan> {
+        let prompt = format!("Plan the following task: {}", task.description);
+        let resp = llm.send_prompt(&prompt).await?;
+        // Very naive parsing: split lines as steps.
+        let steps = resp.lines().map(|l| l.trim().to_string()).collect();
+        Ok(Plan { steps })
+    }
+}

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+
+use crate::llm_manager::LLMProvider;
+
+pub struct Reviewer;
+
+impl Reviewer {
+    pub fn new() -> Self { Self }
+
+    /// Review outputs for correctness.
+    pub async fn review(&self, outputs: &[String], llm: &dyn LLMProvider) -> Result<()> {
+        let joined = outputs.join("\n");
+        let prompt = format!("Review the following outputs:\n{}", joined);
+        let _resp = llm.send_prompt(&prompt).await?;
+        // Placeholder: In a real implementation the response would influence further actions.
+        Ok(())
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use log::info;
+
+/// Placeholder UI handler.
+pub struct UIHandler {
+    pub headless: bool,
+}
+
+impl UIHandler {
+    pub fn new(headless: bool) -> Self { Self { headless } }
+
+    pub fn start(&self) -> Result<()> {
+        if !self.headless {
+            info!("Starting UI");
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add reqwest and serde dependencies
- implement real LLM providers for OpenAI, Anthropic, OpenRouter, xAI, and ollama
- pick provider via `LLM_PROVIDER` environment variable
- remove dummy echo provider and iterate until review succeeds
- document provider configuration in README

## Testing
- `cargo build` *(fails: no matching package named `async-trait`)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683aadc18548832e8f4d4b7ffb6712d4