### PR TITLE
Update README instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cli_engineer"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tokio = { version = "1.36", features = ["full"] }
+thiserror = "1.0"
+log = "0.4"
+simplelog = "0.12"
+anyhow = "1.0"
+async-trait = "0.1"
+clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # cli_engineer
-autonomous CLI coding agent
+
+A skeletal implementation of an autonomous CLI coding agent written in Rust. It demonstrates the overall architecture with pluggable LLM providers, task interpretation, planning, execution, review and an agentic loop.
+
+## Developer Setup
+
+Clone the repository and build it locally:
+
+```bash
+cargo build
+cargo test
+```
+
+Run the agent directly with:
+
+```bash
+cargo run -- --verbose "generate hello world"
+```
+
+## User Installation
+
+Once published on crates.io the tool can be installed with:
+
+```bash
+cargo install cli_engineer
+cli_engineer --help
+```
+
+Use `--headless` to disable UI output.

--- a/src/agentic_loop.rs
+++ b/src/agentic_loop.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use log::{info, error};
+
+use crate::interpreter::{Interpreter, Task};
+use crate::planner::{Planner, Plan};
+use crate::executor::Executor;
+use crate::reviewer::Reviewer;
+use crate::llm_manager::{LLMManager, LLMProvider};
+
+/// Controls the iterative planning-action-review cycle.
+pub struct AgenticLoop<'a> {
+    interpreter: Interpreter,
+    planner: Planner,
+    executor: Executor,
+    reviewer: Reviewer,
+    llm_manager: &'a LLMManager,
+    max_iterations: usize,
+}
+
+impl<'a> AgenticLoop<'a> {
+    pub fn new(llm_manager: &'a LLMManager, max_iterations: usize) -> Self {
+        Self {
+            interpreter: Interpreter::new(),
+            planner: Planner::new(),
+            executor: Executor::new(),
+            reviewer: Reviewer::new(),
+            llm_manager,
+            max_iterations,
+        }
+    }
+
+    /// Run the agentic loop on the given input.
+    pub async fn run(&self, input: &str) -> Result<()> {
+        let task = self.interpreter.interpret(input)?;
+        info!("Interpreted task: {}", task.description);
+        let provider = self.llm_manager.provider();
+        let mut iteration = 0;
+        loop {
+            if iteration >= self.max_iterations {
+                info!("Reached max iterations");
+                break;
+            }
+            iteration += 1;
+            info!("Planning iteration {}", iteration);
+            let plan: Plan = self.planner.plan(&task, provider).await?;
+            info!("Plan: {:?}", plan.steps);
+            let outputs = self.executor.execute(&plan, provider).await?;
+            info!("Execution complete");
+            if let Err(err) = self.reviewer.review(&outputs, provider).await {
+                error!("Review failed: {}", err);
+            }
+            // For now exit after one iteration.
+            break;
+        }
+        Ok(())
+    }
+}

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use tokio::task::JoinHandle;
+
+/// Runs tasks concurrently using tokio.
+pub async fn run_parallel<T, F>(futs: Vec<F>) -> Result<Vec<T>>
+where
+    F: std::future::Future<Output = Result<T>> + Send + 'static,
+    T: Send + 'static,
+{
+    let handles: Vec<JoinHandle<Result<T>>> = futs
+        .into_iter()
+        .map(|f| tokio::spawn(f))
+        .collect();
+
+    let mut out = Vec::new();
+    for handle in handles {
+        out.push(handle.await??);
+    }
+    Ok(out)
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+
+use crate::llm_manager::LLMProvider;
+use crate::planner::Plan;
+
+/// Executes planned steps using a coding LLM.
+pub struct Executor;
+
+impl Executor {
+    pub fn new() -> Self { Self }
+
+    /// Execute each step and collect the responses.
+    pub async fn execute(&self, plan: &Plan, llm: &dyn LLMProvider) -> Result<Vec<String>> {
+        let mut outputs = Vec::new();
+        for step in &plan.steps {
+            let prompt = format!("Execute step: {}", step);
+            let resp = llm.send_prompt(&prompt).await?;
+            outputs.push(resp);
+        }
+        Ok(outputs)
+    }
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+
+/// Represents a parsed user task.
+#[derive(Debug, Clone)]
+pub struct Task {
+    pub description: String,
+}
+
+/// Interprets raw input into a `Task`.
+pub struct Interpreter;
+
+impl Interpreter {
+    pub fn new() -> Self { Self }
+
+    /// Interpret user input into a `Task`.
+    pub fn interpret(&self, input: &str) -> Result<Task> {
+        // For now just wrap the input.
+        Ok(Task { description: input.to_string() })
+    }
+}

--- a/src/llm_manager.rs
+++ b/src/llm_manager.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Trait representing an LLM provider.
+#[async_trait]
+pub trait LLMProvider: Send + Sync {
+    /// Name of the provider.
+    fn name(&self) -> &str;
+
+    /// Maximum context size in tokens.
+    fn context_size(&self) -> usize;
+
+    /// Send a prompt to the provider and return the response.
+    async fn send_prompt(&self, prompt: &str) -> Result<String>;
+}
+
+/// Dummy provider used when no remote LLM is available.
+pub struct LocalProvider;
+
+#[async_trait]
+impl LLMProvider for LocalProvider {
+    fn name(&self) -> &str { "local" }
+
+    fn context_size(&self) -> usize { 4096 }
+
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        // For now we simply echo the prompt as a placeholder.
+        Ok(format!("Echo: {}", prompt))
+    }
+}
+
+/// Manager that keeps track of multiple providers and context limits.
+pub struct LLMManager {
+    providers: Vec<Box<dyn LLMProvider>>,
+    active: usize,
+}
+
+impl LLMManager {
+    /// Create a new manager with the given providers.
+    pub fn new(providers: Vec<Box<dyn LLMProvider>>) -> Self {
+        Self { providers, active: 0 }
+    }
+
+    /// Get the active provider.
+    pub fn provider(&self) -> &dyn LLMProvider {
+        &*self.providers[self.active]
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,6 @@
+use simplelog::{Config, LevelFilter, SimpleLogger};
+
+pub fn init(verbose: bool) {
+    let level = if verbose { LevelFilter::Info } else { LevelFilter::Warn };
+    let _ = SimpleLogger::init(level, Config::default());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,42 @@
+use clap::Parser;
+
+mod llm_manager;
+mod interpreter;
+mod planner;
+mod executor;
+mod reviewer;
+mod agentic_loop;
+mod concurrency;
+mod ui;
+mod logger;
+
+use llm_manager::{LLMManager, LocalProvider};
+use agentic_loop::AgenticLoop;
+
+#[derive(Parser)]
+#[command(name = "cli_engineer")]
+struct Args {
+    /// Run without UI output
+    #[arg(short, long)]
+    headless: bool,
+    /// Verbose logging
+    #[arg(short, long)]
+    verbose: bool,
+    /// Command or natural language instruction
+    #[arg(last = true)]
+    command: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    logger::init(args.verbose);
+    let ui = ui::UIHandler::new(args.headless);
+    ui.start()?;
+    // In a real implementation we would configure multiple providers
+    let llm_manager = LLMManager::new(vec![Box::new(LocalProvider)]);
+    let agent = AgenticLoop::new(&llm_manager, 1);
+    let input = args.command.join(" ");
+    agent.run(&input).await?;
+    Ok(())
+}

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+
+use crate::interpreter::Task;
+use crate::llm_manager::LLMProvider;
+
+/// Represents a sequence of steps to perform.
+#[derive(Debug, Clone)]
+pub struct Plan {
+    pub steps: Vec<String>,
+}
+
+pub struct Planner;
+
+impl Planner {
+    pub fn new() -> Self { Self }
+
+    /// Create a plan for the given task using the provided LLM.
+    pub async fn plan(&self, task: &Task, llm: &dyn LLMProvider) -> Result<Plan> {
+        let prompt = format!("Plan the following task: {}", task.description);
+        let resp = llm.send_prompt(&prompt).await?;
+        // Very naive parsing: split lines as steps.
+        let steps = resp.lines().map(|l| l.trim().to_string()).collect();
+        Ok(Plan { steps })
+    }
+}

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+
+use crate::llm_manager::LLMProvider;
+
+pub struct Reviewer;
+
+impl Reviewer {
+    pub fn new() -> Self { Self }
+
+    /// Review outputs for correctness.
+    pub async fn review(&self, outputs: &[String], llm: &dyn LLMProvider) -> Result<()> {
+        let joined = outputs.join("\n");
+        let prompt = format!("Review the following outputs:\n{}", joined);
+        let _resp = llm.send_prompt(&prompt).await?;
+        // Placeholder: In a real implementation the response would influence further actions.
+        Ok(())
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+use log::info;
+
+/// Placeholder UI handler.
+pub struct UIHandler {
+    pub headless: bool,
+}
+
+impl UIHandler {
+    pub fn new(headless: bool) -> Self { Self { headless } }
+
+    pub fn start(&self) -> Result<()> {
+        if !self.headless {
+            info!("Starting UI");
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- clarify README with separate developer and user sections
- remove network disclaimer and provide install example

## Testing
- `cargo build` *(fails: no matching package named `async-trait` found)*
- `cargo test` *(fails: no matching package named `async-trait` found)*

------
https://chatgpt.com/codex/tasks/task_e_683aadc18548832e8f4d4b7ffb6712d4