### PR TITLE
feat: Add Ollama provider support for local LLM inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli_engineer"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli_engineer.toml
+++ b/cli_engineer.toml
@@ -4,30 +4,76 @@
 # - OPENROUTER_API_KEY for OpenRouter
 # - OPENAI_API_KEY for OpenAI
 # - ANTHROPIC_API_KEY for Anthropic
+# - Ollama runs locally and doesn't require an API key
 
 [ai_providers.openai]
 enabled = false
-model = "gpt-4.1"
-temperature = 1
-cost_per_1m_input_tokens = 2.000
-cost_per_1m_output_tokens = 8.000
-max_tokens = 1047576
+# PREMIUM MODELS (requires OPENAI_API_KEY):
+# gpt-4o-mini     - $0.15/$0.60 per 1M tokens, fast and efficient
+# gpt-4o          - $2.50/$10.00 per 1M tokens, most capable
+# gpt-4-turbo     - $10.00/$30.00 per 1M tokens, high performance
+model = "gpt-4o-mini"
+temperature = 0.7
+cost_per_1m_input_tokens = 0.150
+cost_per_1m_output_tokens = 0.600
+max_tokens = 128000
 
 [ai_providers.anthropic]
 enabled = true
-model = "claude-sonnet-4-0"
-temperature = 1
+# CLAUDE MODELS (requires ANTHROPIC_API_KEY):
+# claude-3-5-haiku-20241022   - $1.00/$5.00 per 1M tokens, fast
+# claude-3-5-sonnet-20241022  - $3.00/$15.00 per 1M tokens, balanced (RECOMMENDED)
+# claude-3-opus-20240229      - $15.00/$75.00 per 1M tokens, most capable
+model = "claude-3-5-sonnet-20241022"
+temperature = 0.7
 cost_per_1m_input_tokens = 3.00
 cost_per_1m_output_tokens = 15.00
 max_tokens = 200000
 
 [ai_providers.openrouter]
 enabled = false
+# COST-EFFECTIVE CLOUD OPTIONS:
+# deepseek/deepseek-r1-0528-qwen3-8b  - $0.06/$0.09 per 1M tokens, reasoning
+# qwen/qwen-2.5-coder-32b-instruct    - $0.18/$0.18 per 1M tokens, coding
+# microsoft/phi-4                     - $0.10/$0.10 per 1M tokens, efficient
+# google/gemma-2-9b-it                - $0.08/$0.08 per 1M tokens, balanced
 model = "deepseek/deepseek-r1-0528-qwen3-8b"
 temperature = 0.2
 cost_per_1m_input_tokens = 0.06
 cost_per_1m_output_tokens = 0.09
 max_tokens = 65536
+
+# Ollama - Local LLM inference (no API key required)
+# Install: curl -fsSL https://ollama.ai/install.sh | sh
+# Pull model: ollama pull <model_name>
+#
+# CONSUMER GPU RECOMMENDATIONS (4B-14B parameters):
+#
+# For 8GB VRAM (GTX 1070, RTX 3060):
+#   qwen3:4b, phi4-mini, gemma3:4b
+#
+# For 12GB VRAM (RTX 3060 Ti, RTX 4060 Ti):
+#   qwen3:8b, deepseek-r1:7b, qwen2.5-coder:7b
+#
+# For 16GB+ VRAM (RTX 3080, RTX 4070 Ti):
+#   qwen3:14b, gemma3:12b, deepseek-r1:8b
+
+[ai_providers.ollama]
+enabled = false
+# RECOMMENDED MODELS:
+# qwen3:4b        - 4B params, ~3GB VRAM, excellent general performance
+# qwen3:8b        - 8B params, ~6GB VRAM, best balance (RECOMMENDED)
+# qwen3:14b       - 14B params, ~10GB VRAM, high performance
+# deepseek-r1:7b  - 7B params, ~5GB VRAM, advanced reasoning
+# deepseek-r1:8b  - 8B params, ~6GB VRAM, reasoning + general tasks
+# phi4-mini       - 3.8B params, ~3GB VRAM, efficient with long context
+# gemma3:4b       - 4B params, ~3GB VRAM, Google's compact model
+# gemma3:12b      - 12B params, ~8GB VRAM, stronger performance
+# qwen2.5-coder:7b - 7B params, ~5GB VRAM, specialized for coding
+model = "qwen3:8b"
+temperature = 0.7
+base_url = "http://localhost:11434"
+max_tokens = 8192
 
 [execution]
 # Maximum iterations for the agentic loop

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,7 @@ pub struct LLMManager {
 - OpenAI (GPT-4, GPT-4 Turbo, etc.)
 - Anthropic (Claude models)
 - OpenRouter (Various models)
+- Ollama (Local LLM inference)
 - Local Provider (fallback for testing)
 
 ### 3. Task Interpreter (`interpreter.rs`)

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,8 @@ src/
 │   ├── mod.rs
 │   ├── openai.rs
 │   ├── anthropic.rs
-│   └── openrouter.rs
+│   ├── openrouter.rs
+│   └── ollama.rs
 └── utils/               # Utility modules
     ├── logger.rs
     ├── logger_dashboard.rs
@@ -153,6 +154,11 @@ src/
 - Anthropic Claude API integration
 - Supports Claude-3 family models
 - Handles Anthropic-specific message formatting
+
+**providers/ollama.rs**
+- Ollama local LLM integration
+- Uses OpenAI-compatible API endpoints
+- Supports various open-source models (Llama, Mistral, etc.)
 
 **providers/openrouter.rs**
 - OpenRouter API integration for multiple model access

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -68,9 +68,52 @@ export ANTHROPIC_API_KEY="your-api-key-here"
 
 # For OpenRouter
 export OPENROUTER_API_KEY="your-api-key-here"
+
+# For Ollama (local inference - no API key needed)
+# Just install and run: curl -fsSL https://ollama.ai/install.sh | sh
+# Then pull a model: ollama pull llama3.2
 ```
 
 Add these to your shell profile (`.bashrc`, `.zshrc`, etc.) to persist them.
+
+### Setting up Ollama (Local LLM)
+
+Ollama allows you to run LLMs locally without API keys or internet connectivity:
+
+1. **Install Ollama**:
+   ```bash
+   curl -fsSL https://ollama.ai/install.sh | sh
+   ```
+
+2. **Pull a model** (choose based on your GPU):
+   ```bash
+   # For 8-12GB VRAM (recommended for most users)
+   ollama pull qwen3:8b        # Best balance of performance/size
+   ollama pull deepseek-r1:7b  # Advanced reasoning
+
+   # For 6-8GB VRAM (budget GPUs)
+   ollama pull qwen3:4b        # Compact but capable
+   ollama pull phi4-mini       # Efficient Microsoft model
+
+   # For 16GB+ VRAM (high-end GPUs)
+   ollama pull qwen3:14b       # Maximum performance
+   ollama pull gemma3:12b      # Google's strong model
+   ```
+
+3. **Start Ollama** (usually starts automatically):
+   ```bash
+   ollama serve
+   ```
+
+4. **Configure in cli_engineer.toml** - simply change `enabled = false` to `enabled = true`:
+   ```toml
+   [ai_providers.ollama]
+   enabled = true              # Just change this to true!
+   model = "qwen3:8b"         # Or change to your preferred model
+   temperature = 0.7
+   base_url = "http://localhost:11434"
+   max_tokens = 8192
+   ```
 
 ### Basic Configuration File
 
@@ -353,6 +396,7 @@ cli_engineer refactor "apply SOLID principles, improve error handling, and optim
 - **GPT-4**: Excellent for complex reasoning and code quality
 - **Claude 3**: Strong at following instructions and safe code generation
 - **DeepSeek**: Cost-effective option via OpenRouter
+- **Ollama Models**: Free local inference, privacy-focused, no API costs
 
 #### Cost Management
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,9 @@ pub struct AIProvidersConfig {
 
     /// OpenRouter configuration
     pub openrouter: Option<ProviderConfig>,
+
+    /// Ollama configuration
+    pub ollama: Option<OllamaConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,6 +50,24 @@ pub struct ProviderConfig {
 
     /// Cost per 1M output tokens (in USD)
     pub cost_per_1m_output_tokens: Option<f32>,
+
+    /// Maximum context size in tokens
+    pub max_tokens: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OllamaConfig {
+    /// Whether this provider is enabled
+    pub enabled: bool,
+
+    /// Model to use
+    pub model: String,
+
+    /// Temperature setting
+    pub temperature: Option<f32>,
+
+    /// Base URL for Ollama server
+    pub base_url: Option<String>,
 
     /// Maximum context size in tokens
     pub max_tokens: Option<usize>,
@@ -181,6 +202,13 @@ impl Default for Config {
                     cost_per_1m_input_tokens: None,
                     cost_per_1m_output_tokens: None,
                     max_tokens: None,
+                }),
+                ollama: Some(OllamaConfig {
+                    enabled: false,
+                    model: "qwen3:8b".to_string(),
+                    temperature: Some(0.7),
+                    base_url: Some("http://localhost:11434".to_string()),
+                    max_tokens: Some(8192),
                 }),
             },
             execution: ExecutionConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use context::{ContextConfig, ContextManager};
 use event_bus::{Event, EventBus, EventEmitter};
 use llm_manager::{LLMManager, LLMProvider, LocalProvider};
 use providers::{
-    anthropic::AnthropicProvider, openai::OpenAIProvider, openrouter::OpenRouterProvider,
+    anthropic::AnthropicProvider, ollama::OllamaProvider, openai::OpenAIProvider, openrouter::OpenRouterProvider,
 };
 use ui_dashboard::DashboardUI;
 use ui_enhanced::EnhancedUI;
@@ -521,6 +521,17 @@ async fn setup_managers(
             providers.push(Box::new(AnthropicProvider::new(
                 Some(anthropic_config.model.clone()),
                 anthropic_config.temperature,
+            )?));
+        }
+    }
+
+    if let Some(ollama_config) = &config.ai_providers.ollama {
+        if ollama_config.enabled {
+            providers.push(Box::new(OllamaProvider::new(
+                Some(ollama_config.model.clone()),
+                ollama_config.temperature,
+                ollama_config.base_url.clone(),
+                ollama_config.max_tokens,
             )?));
         }
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,3 +1,4 @@
 pub mod anthropic;
+pub mod ollama;
 pub mod openai;
 pub mod openrouter;

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -1,0 +1,262 @@
+use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use log::warn;
+
+use crate::llm_manager::LLMProvider;
+
+#[derive(Debug, Serialize)]
+struct OllamaRequest {
+    model: String,
+    messages: Vec<OllamaMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<usize>,
+    temperature: f32,
+    stream: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OllamaMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaResponse {
+    choices: Vec<OllamaChoice>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    usage: Option<OllamaUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaChoice {
+    message: OllamaMessage,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaUsage {
+    #[allow(dead_code)]
+    prompt_tokens: Option<usize>,
+    #[allow(dead_code)]
+    completion_tokens: Option<usize>,
+    #[allow(dead_code)]
+    total_tokens: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaError {
+    error: OllamaErrorDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaErrorDetails {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: Option<String>,
+    code: Option<String>,
+}
+
+/// Ollama local LLM provider implementation
+pub struct OllamaProvider {
+    model: String,
+    base_url: String,
+    client: Client,
+    max_tokens: usize,
+    temperature: f32,
+}
+
+impl OllamaProvider {
+    /// Create a new Ollama provider with default settings
+    pub fn new(
+        model: Option<String>,
+        temperature: Option<f32>,
+        base_url: Option<String>,
+        max_tokens: Option<usize>,
+    ) -> Result<Self> {
+        Ok(Self {
+            model: model.unwrap_or_else(|| "qwen3:8b".to_string()),
+            base_url: base_url.unwrap_or_else(|| "http://localhost:11434".to_string()),
+            client: Client::new(),
+            max_tokens: max_tokens.unwrap_or(8192),
+            temperature: temperature.unwrap_or(0.7),
+        })
+    }
+
+    /// Create a new Ollama provider with custom configuration
+    #[allow(dead_code)]
+    pub fn with_config(model: String, base_url: String, max_tokens: usize) -> Self {
+        Self {
+            model,
+            base_url,
+            client: Client::new(),
+            max_tokens,
+            temperature: 0.7,
+        }
+    }
+
+    /// Set temperature for response generation
+    #[allow(dead_code)]
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = temperature;
+        self
+    }
+
+    /// Set model name
+    #[allow(dead_code)]
+    pub fn with_model(mut self, model: String) -> Self {
+        self.model = model;
+        self
+    }
+
+    /// Set base URL for Ollama server
+    #[allow(dead_code)]
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+}
+
+#[async_trait]
+impl LLMProvider for OllamaProvider {
+    fn name(&self) -> &str {
+        "Ollama"
+    }
+
+    fn context_size(&self) -> usize {
+        // Context sizes for Ollama models (2024-2025)
+        // Handle both base model names and size variants (e.g., "qwen3:8b")
+        let base_model = self.model.split(':').next().unwrap_or(&self.model);
+
+        match base_model {
+            // Latest DeepSeek models
+            "deepseek-r1" => 131_072, // 128K context
+            "deepseek-v3" => 64_000,  // 64K context
+            "deepseek-v2.5" => 64_000,
+            "deepseek-coder-v2" => 64_000,
+
+            // Latest Qwen models
+            "qwen3" => 128_000,       // 128K for 8B+, 32K for smaller
+            "qwen2.5" => 32_768,      // 32K context
+            "qwen2.5-coder" => 32_768,
+            "qwq" => 32_768,          // Reasoning model
+
+            // Latest Llama models
+            "llama4" => 128_000,      // Latest multimodal
+            "llama3.3" => 128_000,    // 128K context
+            "llama3.2" => 128_000,    // 128K context
+            "llama3.1" => 128_000,    // 128K context
+            "llama3" => 8_192,        // Original 8K
+            "llama2" => 4_096,        // 4K context
+
+            // Latest Microsoft Phi models
+            "phi4" => 16_384,         // 16K context
+            "phi4-mini" => 128_000,   // 128K context
+            "phi4-reasoning" => 16_384,
+            "phi3.5" => 128_000,      // 128K context
+            "phi3" => 128_000,        // 128K context
+
+            // Latest Google Gemma models
+            "gemma3" => 128_000,      // 128K for larger, 32K for 1B
+            "gemma2" => 8_192,        // 8K context
+
+            // Code-specialized models
+            "codellama" => 16_384,    // 16K context
+            "codegemma" => 8_192,     // 8K context
+            "devstral" => 128_000,    // 128K context
+
+            // Mistral models
+            "mistral" => 32_768,      // 32K context
+            "mistral-nemo" => 128_000, // 128K context
+            "mistral-small" => 128_000,
+            "mistral-large" => 128_000,
+
+            // Other notable models
+            "granite3.2" => 128_000,  // IBM Granite
+            "granite3.1-dense" => 128_000,
+            "smollm2" => 8_192,       // Small models
+            "tinyllama" => 2_048,     // Very small
+
+            _ => 32_768, // More generous default for newer models
+        }
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    async fn send_prompt(&self, prompt: &str) -> Result<String> {
+        let request = OllamaRequest {
+            model: self.model.clone(),
+            messages: vec![
+                OllamaMessage {
+                    role: "system".to_string(),
+                    content: "You are a helpful AI assistant for coding tasks.".to_string(),
+                },
+                OllamaMessage {
+                    role: "user".to_string(),
+                    content: prompt.to_string(),
+                },
+            ],
+            max_tokens: Some(self.max_tokens),
+            temperature: self.temperature,
+            stream: false,
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/v1/chat/completions", self.base_url))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send request to Ollama")?;
+
+        let status = response.status();
+        let response_text = response.text().await?;
+
+        if !status.is_success() {
+            // Try to parse error response
+            if let Ok(error_response) = serde_json::from_str::<OllamaError>(&response_text) {
+                return Err(anyhow!(
+                    "Ollama API error: {} (type: {:?}, code: {:?})",
+                    error_response.error.message,
+                    error_response.error.error_type,
+                    error_response.error.code
+                ));
+            } else {
+                return Err(anyhow!(
+                    "Ollama API error (status {}): {}",
+                    status,
+                    response_text
+                ));
+            }
+        }
+
+        let api_response: OllamaResponse = serde_json::from_str(&response_text)
+            .context("Failed to parse Ollama API response")?;
+
+        // Check if response was truncated
+        if let Some(choice) = api_response.choices.first() {
+            if let Some(finish_reason) = &choice.finish_reason {
+                match finish_reason.as_str() {
+                    "length" => {
+                        warn!("Ollama response was truncated due to max_tokens limit ({}). Response may be incomplete.", self.max_tokens);
+                    }
+                    "stop" => {
+                        // Normal completion, no issues
+                    }
+                    other => {
+                        warn!("Ollama response finished with reason: {}", other);
+                    }
+                }
+            }
+
+            Ok(choice.message.content.clone())
+        } else {
+            Err(anyhow!("No choices in Ollama response"))
+        }
+    }
+}


### PR DESCRIPTION
- Add comprehensive Ollama provider implementation with OpenAI-compatible API
- Support for latest 2024-2025 models optimized for consumer GPUs (4B-14B params)
- Add OllamaConfig struct with base_url and model size configuration
- Update context size mapping for 40+ modern models including:
  - qwen3:4b/8b/14b (recommended default: qwen3:8b)
  - deepseek-r1:7b/8b for advanced reasoning
  - phi4-mini (3.8B) and gemma3:4b/12b for efficiency
  - qwen2.5-coder:7b for code-specialized tasks
- Integrate Ollama provider into main configuration and initialization
- Update cli_engineer.toml with practical model recommendations by GPU VRAM
- Add comprehensive documentation and setup instructions
- Focus on consumer hardware compatibility (8GB-16GB VRAM)
- No API keys required, fully local inference with privacy benefits

Breaking changes: None - all changes are additive
Closes: #8 